### PR TITLE
Fix ForStatementAst rebuild

### DIFF
--- a/modules/rebuilder.py
+++ b/modules/rebuilder.py
@@ -192,9 +192,9 @@ class Rebuilder:
             self.write("for(")
             self._rebuild_internal(subnodes[0])
             self.write(";")
-            self._rebuild_internal(subnodes[1])
-            self.write(";")
             self._rebuild_internal(subnodes[3])
+            self.write(";")
+            self._rebuild_internal(subnodes[1])
             self.write(")\n")
 
             self._rebuild_internal(subnodes[2])


### PR DESCRIPTION
I noticed that in `for` statements, the condition and update statements are swapped after a rebuild. The node order in some of the statement types seems pretty random in general - not sure what Microsoft was thinking. I tested this under PS 5.1 and 7.3.

Example script:
```ps1
for ($i = 0; $i -lt 3; $i++) {
  Write-Host $i
}
```

Would previously be turned into:
```ps1
for($i = 0;$i ++ ;$i -lt 3)
{
   Write-Host $i;
}
```

PS: Great project, I love it! I'll contribute some more stuff in the coming days.