### PR TITLE
Rebuild array expression

### DIFF
--- a/modules/operators.py
+++ b/modules/operators.py
@@ -20,4 +20,5 @@ OPS = {
     "And": " -and ",
     "Or": " -or ",
     "Ilt": " -lt ",
+    "DotDot": "..",
 }

--- a/modules/rebuilder.py
+++ b/modules/rebuilder.py
@@ -309,6 +309,15 @@ class Rebuilder:
                     self.write(", ")
                 self._rebuild_internal(subnode)
 
+        elif node.tag in ["ArrayExpressionAst"]:
+            statement_block = list(node)[0]
+            statements_node = list(statement_block)[0]
+            statements = list(statements_node)
+            if len(statements) > 0:
+                self._rebuild_internal(statements[0])
+            else:
+                self.write("@()")
+
         elif node.tag in ["ArrayLiteralAst"]:
             subnodes = list(list(node)[0])
             self.write("@(")


### PR DESCRIPTION
This PR adds support for rebuilding array expressions, i.e. `@( ... )`.

For some reason the node contains a statement block, so I had to add some indirections so the rebuilder doesn't attempt to add braces and semicolons.

```ps1
$lit = 'a','b'
$expr = @('a','b')

if ($lit.count -eq $expr.count) {
  Write-Host yes
}
```

Furthermore I added support for the DotDot operator, so that slices such as `$expr[0..1]` come out correctly.