### PR TITLE
Add tags for new empty nodes encountered in PS 7.3

### DIFF
--- a/modules/optimizations/empty_nodes.py
+++ b/modules/optimizations/empty_nodes.py
@@ -5,7 +5,8 @@ from modules.utils import delete_node
 
 def opt_remove_empty_nodes(ast):
     for node in ast.iter():
-        if node.tag in ["Attributes", "Redirections", "CatchTypes"]:
+        if node.tag in ("Attributes", "Redirections", "CatchTypes", \
+                        "Operator", "TokenKind", "BlockKind", "InvocationOperator"):
             subnodes = list(node)
             if len(subnodes) == 0:
                 log_debug(f"Remove empty node {node.tag}")


### PR DESCRIPTION
This PR extends the list of empty node names with ones I encountered when running this on PS 7.3.

The `Operator` one is especially important, because its presence screws up indexes in binary expressions.