### PR TITLE
Add optimization that renames extremely long variables

### DIFF
--- a/modules/optimizations/replace_long_names.py
+++ b/modules/optimizations/replace_long_names.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+from modules.logger import log_debug
+
+# Names longer than this will be renamed.
+RENAME_THRESHOLD = 60
+
+VAR_ATTRIB = {
+    "VariableExpressionAst": "VariablePath",
+    "ParameterAst": "Name",
+}
+
+def opt_long_variable_names(ast):
+    counter = 0
+    var_mapping = {}
+    result = False
+
+    for node in ast.iter():
+        if node.tag in ("VariableExpressionAst", "ParameterAst"):
+            name = node.attrib[VAR_ATTRIB[node.tag]]
+
+            has_dollar = False
+            if name[0] == "$":
+                name = name[1:]
+                has_dollar = True
+
+            if len(name) < RENAME_THRESHOLD:
+                continue
+
+            if name not in var_mapping:
+                var_mapping[name] = f"deob_{counter}"
+                log_debug(f"Replacing long variable name {name} with {var_mapping[name]}")
+                counter += 1
+
+            new_name = var_mapping[name]
+            if has_dollar:
+                new_name = f"${new_name}"
+            
+            node.attrib[VAR_ATTRIB[node.tag]] = new_name
+            result = True
+
+    return result

--- a/modules/optimize.py
+++ b/modules/optimize.py
@@ -10,6 +10,7 @@ from modules.optimizations.dead_codes import opt_unused_variable, opt_remove_uni
 from modules.optimizations.empty_nodes import opt_remove_empty_nodes
 from modules.optimizations.invoke_member import opt_invoke_split_string, opt_invoke_replace_string, \
     opt_invoke_reverse_array, opt_invoke_expression
+from modules.optimizations.replace_long_names import opt_long_variable_names
 from modules.optimizations.simplifications import opt_simplify_paren_single_expression, \
     opt_bareword_case, opt_constant_string_type, opt_prefixed_variable_case, opt_replace_constant_variable_by_value, \
     opt_simplify_single_array, opt_simplify_pipeline_single_command, opt_type_constraint_from_convert, \
@@ -47,6 +48,7 @@ def optimize_pass(ast):
         # Complex operations
         opt_value_of_const_array,
         # Syntax simplification
+        opt_long_variable_names,
         opt_prefixed_variable_case,
         opt_bareword_case,
         opt_constant_string_type,


### PR DESCRIPTION
I encountered some obfuscated scripts that have variable names with several hundred characters. This makes it all but impossible to follow what is going on in the script.

I added an optimization pass that makes variable names above a certain length threshold (currently 60) much shorter.

Caveat: If the script dynamically computes names, the output will be incorrect.
```ps1
$foo1 = 1
$dynName = "foo" + (2-1)
$foo2 = Get-Variable -Name $dynName -ValueOnly
$foo3 = $ExecutionContext.SessionState.PSVariable.GetValue($dynName)
$foo4 = Invoke-Expression "`$$dynName"
Write-Host $foo2 $foo3 $foo4
```

However that's not a newly introduced problem with my pass, because deobshell currently already considers such variables dead because it cannot detect the dynamic usage. It might be possible to try to detect dynamic accesses and then skip certain optimizations (and perhaps add a "dangerous" flag that would apply optimizations anyway even if detected).

I also considered doing this for function names, but that seems a bit harder because unlike variable names, function names aren't always in clear cut attributes.