### PR TITLE
Add option to run PowerShell under docker

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,8 @@ def usage():
     print("Options:")
     print("      -h, --help      : Show help")
     print("      -i, --in        : Input .ps1 file")
+    if sys.platform == "linux":
+        print("      --docker        : Run PowerShell under Docker")
     print()
     sys.exit(0)
 
@@ -35,6 +37,8 @@ def parse_args():
         elif sys.argv[i] in ["-i", "--in"]:
             OPTIONS["input"] = sys.argv[i + 1]
             i += 1
+        elif sys.argv[i] == "--docker":
+            OPTIONS["docker"] = True
         else:
             OPTIONS["command"] = sys.argv[i]
         i += 1
@@ -43,7 +47,7 @@ def parse_args():
 def deob(ps1_file):
     p = pathlib.Path(ps1_file)
 
-    if create_ast_file(p):
+    if create_ast_file(p, "docker" in OPTIONS):
 
         if ast := read_ast_file(p.with_suffix(".xml")):
             o = Optimizer()
@@ -59,7 +63,7 @@ def deob(ps1_file):
 def format(ps1_file):
     p = pathlib.Path(ps1_file)
 
-    if create_ast_file(p):
+    if create_ast_file(p, "docker" in OPTIONS):
 
         if ast := read_ast_file(p.with_suffix(".xml")):
             r = Rebuilder(p.with_suffix(".formatted.ps1"))

--- a/modules/ast.py
+++ b/modules/ast.py
@@ -20,16 +20,24 @@ def read_ast_file(filename):
         return None
 
 
-def create_ast_file(ps1_file):
+def create_ast_file(ps1_file, use_docker):
     log_info(f"Creating AST for: {ps1_file}")
 
-    cmd = ["PowerShell", "-ExecutionPolicy", "Unrestricted", "-File",
-           os.path.abspath(os.path.join("tools", "Get-AST.ps1")),
-           "-ps1", os.path.abspath(ps1_file)]
+    if use_docker:
+        cmd = ["docker", "run", "-v", os.path.abspath(os.path.join("tools", "Get-AST.ps1")) + ":/Get-AST.ps1",
+            "-v", os.path.abspath(ps1_file / "..") + ":/scriptdir",
+            "--net", "none", "--rm", "-it", "mcr.microsoft.com/powershell:lts-7.2-ubuntu-22.04",
+            "pwsh", "-File", "/Get-AST.ps1", "-ps1", "/scriptdir/" + ps1_file.name]
+    else:
+        cmd = ["PowerShell", "-ExecutionPolicy", "Unrestricted", "-File",
+            os.path.abspath(os.path.join("tools", "Get-AST.ps1")),
+            "-ps1", os.path.abspath(ps1_file)]
 
     result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
     for line in result.stdout.splitlines():
+        log_debug(line)
+    for line in result.stderr.splitlines():
         log_debug(line)
 
     return result.returncode == 0


### PR DESCRIPTION
Sometimes you may not want to install PowerShell on your system. This PR adds an option to run the Get-AST script in a docker container instead.

This also makes it quite easy to test different versions of PS. Currently, 7.2 (LTS) is hardcoded.