### PR TITLE
Rebuild DoWhile/While/Switch and operators Multiply/Igt

### DIFF
--- a/data/basics/test_do_while.deob.ps1
+++ b/data/basics/test_do_while.deob.ps1
@@ -1,0 +1,5 @@
+$i = 2;
+do {
+   Write-Host $i;
+}
+while ($i-- -gt 0)

--- a/data/basics/test_do_while.deob.xml
+++ b/data/basics/test_do_while.deob.xml
@@ -1,0 +1,41 @@
+<ScriptBlockAst>
+  <UsingStatements/>
+  <NamedBlockAst>
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <DoWhileStatementAst Condition="$i-- -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                  <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                </UnaryExpressionAst>
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </DoWhileStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_do_while.ps1
+++ b/data/basics/test_do_while.ps1
@@ -1,0 +1,4 @@
+$i = 2
+do {
+    Write-Host $i
+} while ($i-- -gt 0);

--- a/data/basics/test_do_while.xml
+++ b/data/basics/test_do_while.xml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ScriptBlockAst>
+  <Attributes />
+  <UsingStatements />
+  <NamedBlockAst>
+    <BlockKind />
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <DoWhileStatementAst Condition="$i-- -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                  <TokenKind />
+                  <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                </UnaryExpressionAst>
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </DoWhileStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_for.deob.ps1
+++ b/data/basics/test_for.deob.ps1
@@ -1,5 +1,21 @@
 
-for($i = 0;$i -lt 3;$i--)
+for ($i = 0; $i -lt 3; $i--)
 {
    Write-Host $i;
+}
+
+for ($i = 0; ; $i++)
+{
+   Write-Host $i;
+   break;
+}
+
+for ($i = 0; $i -lt 3; )
+{
+   Write-Host $i++;
+}
+
+for (; ; )
+{
+   break;
 }

--- a/data/basics/test_for.deob.xml
+++ b/data/basics/test_for.deob.xml
@@ -1,36 +1,119 @@
 <ScriptBlockAst>
-  <UsingStatements />
+  <UsingStatements/>
   <NamedBlockAst>
     <Statements>
       <ForStatementAst Condition="$i -lt 3">
         <AssignmentStatementAst Operator="Equals">
-          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
           <CommandExpressionAst>
             <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
             </CommandExpressionAst>
         </AssignmentStatementAst>
-        <CommandExpressionAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
               <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
-                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
               </UnaryExpressionAst>
               </CommandExpressionAst>
-          <StatementBlockAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
           <Statements>
-            <CommandAst>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host</StringConstantExpressionAst>
-                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
                   </CommandElements>
                   </CommandAst>
-              </Statements>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
         </StatementBlockAst>
-        <CommandExpressionAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
               <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
-                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
                 <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
               </BinaryExpressionAst>
               </CommandExpressionAst>
-          </ForStatementAst>
+          </PipelineElements>
+        </PipelineAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+            </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+              </UnaryExpressionAst>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+            <BreakStatementAst/>
+          </Statements>
+        </StatementBlockAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="$i -lt 3">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+            </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
+                    <ExpandableStringExpressionAst StringConstantType="BareWord" StaticType="string">$i++<StringConstantType/><NestedExpressions><VariableExpressionAst VariablePath="i" StaticType="System.Object"/></NestedExpressions></ExpandableStringExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="">
+        <StatementBlockAst>
+          <Statements>
+            <BreakStatementAst/>
+          </Statements>
+        </StatementBlockAst>
+      </ForStatementAst>
     </Statements>
   </NamedBlockAst>
 </ScriptBlockAst>

--- a/data/basics/test_for.ps1
+++ b/data/basics/test_for.ps1
@@ -1,4 +1,18 @@
 
+# [0] assignment, [1] update (PipelineAst), [2] block, [3] cond (PipelineAst)
 for ($i = 0; $i -lt 3; $i--) {
   Write-Host $i
+}
+# [0] assignment, [1] update (PipelineAst), [2] block
+for ($i = 0; ; $i++) {
+  Write-Host $i
+  break
+}
+# [0] assignment, [1] block, [2] cond (PipelineAst)
+for ($i = 0; $i -lt 3;) {
+  Write-Host $i++
+}
+# [0] block
+for (; ;) {
+  break
 }

--- a/data/basics/test_for.xml
+++ b/data/basics/test_for.xml
@@ -3,10 +3,12 @@
   <Attributes />
   <UsingStatements />
   <NamedBlockAst>
+    <BlockKind />
     <Statements>
       <ForStatementAst Condition="$i -lt 3">
         <AssignmentStatementAst Operator="Equals">
           <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+          <Operator />
           <CommandExpressionAst>
             <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
             <Redirections />
@@ -16,6 +18,7 @@
           <PipelineElements>
             <CommandExpressionAst>
               <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                <TokenKind />
                 <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
               </UnaryExpressionAst>
               <Redirections />
@@ -28,9 +31,10 @@
               <PipelineElements>
                 <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host</StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
                     <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                   </CommandElements>
+                  <InvocationOperator />
                   <Redirections />
                 </CommandAst>
               </PipelineElements>
@@ -41,6 +45,7 @@
           <PipelineElements>
             <CommandExpressionAst>
               <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                <Operator />
                 <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                 <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
               </BinaryExpressionAst>
@@ -48,6 +53,89 @@
             </CommandExpressionAst>
           </PipelineElements>
         </PipelineAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+          <Operator />
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+            <Redirections />
+          </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                <TokenKind />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+              </UnaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+            <BreakStatementAst />
+          </Statements>
+        </StatementBlockAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="$i -lt 3">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+          <Operator />
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+            <Redirections />
+          </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ExpandableStringExpressionAst StringConstantType="BareWord" StaticType="string">$i++<StringConstantType /><NestedExpressions><VariableExpressionAst VariablePath="i" StaticType="System.Object" /></NestedExpressions></ExpandableStringExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                <Operator />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="">
+        <StatementBlockAst>
+          <Statements>
+            <BreakStatementAst />
+          </Statements>
+        </StatementBlockAst>
       </ForStatementAst>
     </Statements>
   </NamedBlockAst>

--- a/data/basics/test_sub_expression.deob.ps1
+++ b/data/basics/test_sub_expression.deob.ps1
@@ -1,0 +1,9 @@
+$a = @(0, 1, 2);
+$foo = $(   
+   for($i = 0;$i -lt $a.Length;$i++)
+   {
+      $a[$i] + 1;
+   }
+   4;
+);
+Write-Host $foo;

--- a/data/basics/test_sub_expression.deob.xml
+++ b/data/basics/test_sub_expression.deob.xml
@@ -1,0 +1,94 @@
+<ScriptBlockAst>
+  <UsingStatements/>
+  <NamedBlockAst>
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="a" StaticType="System.Object"/>
+        <CommandExpressionAst>
+          <ArrayLiteralAst StaticType="System.Object[]">
+            <Elements>
+              <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
+              <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+            </Elements>
+          </ArrayLiteralAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="foo" StaticType="System.Object"/>
+        <CommandExpressionAst>
+          <SubExpressionAst StaticType="System.Object">
+            <StatementBlockAst>
+              <Statements>
+                <ForStatementAst Condition="$i -lt $a.Length">
+                  <AssignmentStatementAst Operator="Equals">
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                    <CommandExpressionAst>
+                      <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+                      </CommandExpressionAst>
+                  </AssignmentStatementAst>
+                  <PipelineAst>
+                    <PipelineElements>
+                      <CommandExpressionAst>
+                        <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                        </UnaryExpressionAst>
+                        </CommandExpressionAst>
+                    </PipelineElements>
+                  </PipelineAst>
+                  <StatementBlockAst>
+                    <Statements>
+                      <PipelineAst>
+                        <PipelineElements>
+                          <CommandExpressionAst>
+                            <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
+                              <IndexExpressionAst StaticType="System.Object">
+                                <VariableExpressionAst VariablePath="a" StaticType="System.Object"/>
+                                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                              </IndexExpressionAst>
+                              <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
+                            </BinaryExpressionAst>
+                            </CommandExpressionAst>
+                        </PipelineElements>
+                      </PipelineAst>
+                    </Statements>
+                  </StatementBlockAst>
+                  <PipelineAst>
+                    <PipelineElements>
+                      <CommandExpressionAst>
+                        <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                          <MemberExpressionAst Static="False" StaticType="System.Object">
+                            <VariableExpressionAst VariablePath="a" StaticType="System.Object"/>
+                            <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Length<StringConstantType/></StringConstantExpressionAst>
+                          </MemberExpressionAst>
+                        </BinaryExpressionAst>
+                        </CommandExpressionAst>
+                    </PipelineElements>
+                  </PipelineAst>
+                </ForStatementAst>
+                <PipelineAst>
+                  <PipelineElements>
+                    <CommandExpressionAst>
+                      <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+                      </CommandExpressionAst>
+                  </PipelineElements>
+                </PipelineAst>
+              </Statements>
+            </StatementBlockAst>
+          </SubExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <PipelineAst>
+        <PipelineElements>
+          <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="foo" StaticType="System.Object"/>
+            </CommandElements>
+            </CommandAst>
+        </PipelineElements>
+      </PipelineAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_sub_expression.ps1
+++ b/data/basics/test_sub_expression.ps1
@@ -1,0 +1,3 @@
+$a = 0,1,2
+$foo = $(for ($i = 0; $i -lt $a.Length; $i++){$a[$i] + 1}; 4)
+Write-Host $foo

--- a/data/basics/test_sub_expression.xml
+++ b/data/basics/test_sub_expression.xml
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ScriptBlockAst>
+  <Attributes />
+  <UsingStatements />
+  <NamedBlockAst>
+    <BlockKind />
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="a" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <ArrayLiteralAst StaticType="System.Object[]">
+            <Elements>
+              <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
+              <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+            </Elements>
+          </ArrayLiteralAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <SubExpressionAst StaticType="System.Object">
+            <StatementBlockAst>
+              <Statements>
+                <ForStatementAst Condition="$i -lt $a.Length">
+                  <AssignmentStatementAst Operator="Equals">
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                    <Operator />
+                    <CommandExpressionAst>
+                      <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+                      <Redirections />
+                    </CommandExpressionAst>
+                  </AssignmentStatementAst>
+                  <PipelineAst>
+                    <PipelineElements>
+                      <CommandExpressionAst>
+                        <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                          <TokenKind />
+                          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                        </UnaryExpressionAst>
+                        <Redirections />
+                      </CommandExpressionAst>
+                    </PipelineElements>
+                  </PipelineAst>
+                  <StatementBlockAst>
+                    <Statements>
+                      <PipelineAst>
+                        <PipelineElements>
+                          <CommandExpressionAst>
+                            <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
+                              <Operator />
+                              <IndexExpressionAst StaticType="System.Object">
+                                <VariableExpressionAst VariablePath="a" StaticType="System.Object" />
+                                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                              </IndexExpressionAst>
+                              <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
+                            </BinaryExpressionAst>
+                            <Redirections />
+                          </CommandExpressionAst>
+                        </PipelineElements>
+                      </PipelineAst>
+                    </Statements>
+                  </StatementBlockAst>
+                  <PipelineAst>
+                    <PipelineElements>
+                      <CommandExpressionAst>
+                        <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                          <Operator />
+                          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                          <MemberExpressionAst Static="False" StaticType="System.Object">
+                            <VariableExpressionAst VariablePath="a" StaticType="System.Object" />
+                            <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Length<StringConstantType /></StringConstantExpressionAst>
+                          </MemberExpressionAst>
+                        </BinaryExpressionAst>
+                        <Redirections />
+                      </CommandExpressionAst>
+                    </PipelineElements>
+                  </PipelineAst>
+                </ForStatementAst>
+                <PipelineAst>
+                  <PipelineElements>
+                    <CommandExpressionAst>
+                      <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+                      <Redirections />
+                    </CommandExpressionAst>
+                  </PipelineElements>
+                </PipelineAst>
+              </Statements>
+            </StatementBlockAst>
+          </SubExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <PipelineAst>
+        <PipelineElements>
+          <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
+            </CommandElements>
+            <InvocationOperator />
+            <Redirections />
+          </CommandAst>
+        </PipelineElements>
+      </PipelineAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_switch_cmdlet.deob.ps1
+++ b/data/basics/test_switch_cmdlet.deob.ps1
@@ -1,15 +1,15 @@
 $variable = "Option2";
 switch -Wildcard ($variable) {
-   "Option1"   {
+   "Option1" {
       Write-Output "Selected Option 1";
    }
-   "Option*"   {
+   "Option*" {
       Write-Output "Selected Option with wildcard match";
    }
-   "AnotherOption"   {
+   "AnotherOption" {
       Write-Output "Selected AnotherOption";
    }
-   default    {
+   default {
       Write-Output "Default Option";
    }
 }

--- a/data/basics/test_switch_cmdlet.deob.ps1
+++ b/data/basics/test_switch_cmdlet.deob.ps1
@@ -1,0 +1,15 @@
+$variable = "Option2";
+switch -Wildcard ($variable) {
+   "Option1"   {
+      Write-Output "Selected Option 1";
+   }
+   "Option*"   {
+      Write-Output "Selected Option with wildcard match";
+   }
+   "AnotherOption"   {
+      Write-Output "Selected AnotherOption";
+   }
+   default    {
+      Write-Output "Default Option";
+   }
+}

--- a/data/basics/test_switch_cmdlet.deob.xml
+++ b/data/basics/test_switch_cmdlet.deob.xml
@@ -1,0 +1,81 @@
+<ScriptBlockAst>
+  <UsingStatements/>
+  <NamedBlockAst>
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+        <CommandExpressionAst>
+          <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType/></StringConstantExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <SwitchStatementAst Flags="Wildcard" Condition="$variable">
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option1<StringConstantType/></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 1<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option*<StringConstantType/></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option with wildcard match<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">AnotherOption<StringConstantType/></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected AnotherOption<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </SwitchStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_switch_cmdlet.ps1
+++ b/data/basics/test_switch_cmdlet.ps1
@@ -1,0 +1,16 @@
+$variable = "Option2"
+
+switch -Wildcard ($variable) {
+    "Option1" {
+        Write-Output "Selected Option 1"
+    }
+    "Option*" {
+        Write-Output "Selected Option with wildcard match"
+    }
+    "AnotherOption" {
+        Write-Output "Selected AnotherOption"
+    }
+    default {
+        Write-Output "Default Option"
+    }
+}

--- a/data/basics/test_switch_cmdlet.xml
+++ b/data/basics/test_switch_cmdlet.xml
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ScriptBlockAst>
+  <Attributes />
+  <UsingStatements />
+  <NamedBlockAst>
+    <BlockKind />
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType /></StringConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <SwitchStatementAst Flags="Wildcard" Condition="$variable">
+        <Flags />
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option1<StringConstantType /></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 1<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option*<StringConstantType /></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option with wildcard match<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">AnotherOption<StringConstantType /></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected AnotherOption<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </SwitchStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_switch_statement.deob.ps1
+++ b/data/basics/test_switch_statement.deob.ps1
@@ -1,20 +1,20 @@
 $variable = "Option2";
 switch ($variable) {
-   "Option1"   {
+   "Option1" {
       Write-Output "Selected Option 1";
    }
-   "Option2"   {
+   "Option2" {
       Write-Output "Selected Option 2";
    }
-   "Option3"   {
+   "Option3" {
       Write-Output "Selected Option 3";
    }
-   default    {
+   default {
       Write-Output "Default Option";
    }
 }
 switch ($variable) {
-   default    {
+   default {
       Write-Output "Default Option";
    }
 }

--- a/data/basics/test_switch_statement.deob.ps1
+++ b/data/basics/test_switch_statement.deob.ps1
@@ -1,0 +1,20 @@
+$variable = "Option2";
+switch ($variable) {
+   "Option1"   {
+      Write-Output "Selected Option 1";
+   }
+   "Option2"   {
+      Write-Output "Selected Option 2";
+   }
+   "Option3"   {
+      Write-Output "Selected Option 3";
+   }
+   default    {
+      Write-Output "Default Option";
+   }
+}
+switch ($variable) {
+   default    {
+      Write-Output "Default Option";
+   }
+}

--- a/data/basics/test_switch_statement.deob.xml
+++ b/data/basics/test_switch_statement.deob.xml
@@ -1,0 +1,104 @@
+<ScriptBlockAst>
+  <UsingStatements/>
+  <NamedBlockAst>
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+        <CommandExpressionAst>
+          <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType/></StringConstantExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <SwitchStatementAst Flags="None" Condition="$variable">
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option1<StringConstantType/></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 1<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType/></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 2<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option3<StringConstantType/></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 3<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </SwitchStatementAst>
+      <SwitchStatementAst Flags="None" Condition="$variable">
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType/></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </SwitchStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_switch_statement.ps1
+++ b/data/basics/test_switch_statement.ps1
@@ -1,0 +1,22 @@
+$variable = "Option2"
+
+switch ($variable) {
+    "Option1" {
+        Write-Output "Selected Option 1"
+    }
+    "Option2" {
+        Write-Output "Selected Option 2"
+    }
+    "Option3" {
+        Write-Output "Selected Option 3"
+    }
+    default {
+        Write-Output "Default Option"
+    }
+}
+
+switch ($variable) {
+    default {
+        Write-Output "Default Option"
+    }
+}

--- a/data/basics/test_switch_statement.xml
+++ b/data/basics/test_switch_statement.xml
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ScriptBlockAst>
+  <Attributes />
+  <UsingStatements />
+  <NamedBlockAst>
+    <BlockKind />
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType /></StringConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <SwitchStatementAst Flags="None" Condition="$variable">
+        <Flags />
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option1<StringConstantType /></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 1<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType /></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 2<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option3<StringConstantType /></StringConstantExpressionAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 3<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </SwitchStatementAst>
+      <SwitchStatementAst Flags="None" Condition="$variable">
+        <Flags />
+        <Clauses />
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </SwitchStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_while.deob.ps1
+++ b/data/basics/test_while.deob.ps1
@@ -1,0 +1,5 @@
+$i = 2;
+while ($i-- -gt 0)
+{
+   Write-Host $i;
+}

--- a/data/basics/test_while.deob.xml
+++ b/data/basics/test_while.deob.xml
@@ -1,0 +1,41 @@
+<ScriptBlockAst>
+  <UsingStatements/>
+  <NamedBlockAst>
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <WhileStatementAst Condition="$i-- -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                  </CommandElements>
+                  </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                  <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                </UnaryExpressionAst>
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </WhileStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_while.ps1
+++ b/data/basics/test_while.ps1
@@ -1,0 +1,4 @@
+$i = 2
+while ($i-- -gt 0) {
+    Write-Host $i
+}

--- a/data/basics/test_while.xml
+++ b/data/basics/test_while.xml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ScriptBlockAst>
+  <Attributes />
+  <UsingStatements />
+  <NamedBlockAst>
+    <BlockKind />
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <WhileStatementAst Condition="$i-- -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                  <TokenKind />
+                  <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                </UnaryExpressionAst>
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </WhileStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/modules/operators.py
+++ b/modules/operators.py
@@ -2,6 +2,7 @@
 OPS = {
     "Minus": " - ",
     "Plus": " + ",
+    "Multiply": " * ",
     "Format": " -f ",
     "Equals": " = ",
     "PlusEquals": " += ",
@@ -11,7 +12,9 @@ OPS = {
     "As": " -as ",
     "Ieq": " -eq ",
     "Ige": " -ge ",
+    "Igt": " -gt ",
     "Ile": " -le ",
+    "Ilt": " -lt ",
     "Ine": " -ne ",
     "Bxor": " -bxor ",
     "Ireplace": " -replace ",
@@ -19,6 +22,5 @@ OPS = {
     "Imatch": " -match ",
     "And": " -and ",
     "Or": " -or ",
-    "Ilt": " -lt ",
     "DotDot": "..",
 }

--- a/modules/rebuilder.py
+++ b/modules/rebuilder.py
@@ -261,7 +261,10 @@ class Rebuilder:
                 self.write("}\n")
 
         elif node.tag in ["StatementBlockAst"]:
-            self.indent()
+            if node not in self._parent_map or self._parent_map[node].tag != "SwitchStatementAst":
+                self.indent()
+            else:
+                self.write(" ")
             self.write("{\n")
 
             self._level += 1
@@ -511,10 +514,11 @@ class Rebuilder:
                     self.indent()
                 elif i == default_index:
                     self.indent()
-                    self.write("default ")
+                    self.write("default")
                 self._rebuild_internal(subnode)
 
             self._level -= 1
+            self.indent()
             self.write("}\n")
 
         else:

--- a/modules/rebuilder.py
+++ b/modules/rebuilder.py
@@ -550,6 +550,23 @@ class Rebuilder:
             self.indent()
             self.write("}\n")
 
+        elif node.tag in ["SubExpressionAst"]:
+            self.write("$(")
+
+            subnodes = list(node)
+            if subnodes:
+                self._level += 1
+
+                if subnodes[0].tag == "StatementBlockAst":
+                    self._rebuild_internal(subnodes[0][0])
+                else:
+                    log_warn(f"{subnodes[0].tag} unsupported in SubExpressionAst")
+
+                self._level -= 1
+                self.indent()
+
+            self.write(")")
+
         else:
             log_warn(f"NodeType: {node.tag} unsupported")
 

--- a/tools/Get-AST.ps1
+++ b/tools/Get-AST.ps1
@@ -95,7 +95,7 @@ function AddChildNode($xmlWriter, $child)
 
         foreach ($property in $child.PSObject.Properties)
         {
-            if ($property.Name -in 'Name', 'ArgumentName', 'ParameterName', 'StaticType', 'StringConstantType', 'TypeName', 'VariablePath', 'Operator', 'Variable', 'Condition', 'Static', 'TokenKind')
+            if ($property.Name -in 'Name', 'ArgumentName', 'ParameterName', 'StaticType', 'StringConstantType', 'TypeName', 'VariablePath', 'Operator', 'Variable', 'Condition', 'Static', 'TokenKind', 'Flags')
             {
                 $xmlWriter.WriteAttributeString($property.Name, $property.Value);
             }


### PR DESCRIPTION
This PR adds rebuild support for a couple of things:
* Switch statement
* Switch cmdlet
* While statement
* DoWhile statement
* SubExpression
* Operator Multiply (`*`)
* Operator Igt (`>`)

It also fixes issues with rebuilding `for` statements that are lacking one or more parts of the header.