### PR TITLE
New optimizations

### DIFF
--- a/data/basics/test_deob_edge_cases.deob.ps1
+++ b/data/basics/test_deob_edge_cases.deob.ps1
@@ -1,0 +1,17 @@
+$i = 2;
+while ($i -gt 0)
+{
+   $unassgn = 4;
+   $i--;
+}
+Write-Host $unassgn;
+$j = 2;
+while ($j -gt 0)
+{
+   Write-Host ($j + 1);
+   Write-Host 5;
+   $j--;
+}
+$foo = -5;
+Write-Host $foo;
+Write-Host "hi";

--- a/data/basics/test_deob_edge_cases.deob.xml
+++ b/data/basics/test_deob_edge_cases.deob.xml
@@ -1,0 +1,100 @@
+<ScriptBlockAst>
+  <UsingStatements />
+  <NamedBlockAst>
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <WhileStatementAst Condition="$i -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <AssignmentStatementAst Operator="Equals">
+              <VariableExpressionAst VariablePath="unassgn" StaticType="System.Object" />
+              <CommandExpressionAst>
+                <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+                </CommandExpressionAst>
+            </AssignmentStatementAst>
+            <CommandExpressionAst>
+                  <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </UnaryExpressionAst>
+                  </CommandExpressionAst>
+              </Statements>
+        </StatementBlockAst>
+        <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              </CommandExpressionAst>
+          </WhileStatementAst>
+      <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="unassgn" StaticType="System.Object" />
+            </CommandElements>
+            </CommandAst>
+        <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <WhileStatementAst Condition="$j -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ParenExpressionAst StaticType="System.Object">
+                      <CommandExpressionAst>
+                            <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
+                              <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+                              <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
+                            </BinaryExpressionAst>
+                            </CommandExpressionAst>
+                        </ParenExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ConstantExpressionAst StaticType="int">5</ConstantExpressionAst></CommandElements>
+                  </CommandAst>
+              <CommandExpressionAst>
+                  <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                    <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+                  </UnaryExpressionAst>
+                  </CommandExpressionAst>
+              </Statements>
+        </StatementBlockAst>
+        <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              </CommandExpressionAst>
+          </WhileStatementAst>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">-5</ConstantExpressionAst></CommandExpressionAst>
+      </AssignmentStatementAst>
+      <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
+            </CommandElements>
+            </CommandAst>
+        <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">hi<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_deob_edge_cases.ps1
+++ b/data/basics/test_deob_edge_cases.ps1
@@ -1,0 +1,35 @@
+$i = 2;
+while ($i -gt 0) {
+  # Must not remove usage of $unassgn
+  $unassgn = $unassn + 4;
+  $i--;
+}
+Write-Host $unassgn
+
+$j = 2;
+$yessub = 5;
+while ($j -gt 0)
+{
+  # Must not substitute $j+1 with 3
+  Write-Host ($j+1);
+  Write-Host ($yessub+0);
+  $j--;
+}
+
+# Must replace $nothere with 0 instead of stripping the operation
+$foo = $nothere - 5
+Write-Host $foo
+
+# Completely gone
+if (5 -gt 6) {
+    Write-Host
+}
+
+if (5 -gt 6) {
+    Write-Host
+} elseif (6 -gt 7) {
+    Write-Host
+} else {
+    # This clause is lifted
+    Write-Host "hi"
+}

--- a/data/basics/test_deob_edge_cases.xml
+++ b/data/basics/test_deob_edge_cases.xml
@@ -1,0 +1,291 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ScriptBlockAst>
+  <Attributes />
+  <UsingStatements />
+  <NamedBlockAst>
+    <BlockKind />
+    <Statements>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <WhileStatementAst Condition="$i -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <AssignmentStatementAst Operator="Equals">
+              <VariableExpressionAst VariablePath="unassgn" StaticType="System.Object" />
+              <Operator />
+              <CommandExpressionAst>
+                <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
+                  <Operator />
+                  <VariableExpressionAst VariablePath="unassn" StaticType="System.Object" />
+                  <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+                </BinaryExpressionAst>
+                <Redirections />
+              </CommandExpressionAst>
+            </AssignmentStatementAst>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandExpressionAst>
+                  <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                    <TokenKind />
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </UnaryExpressionAst>
+                  <Redirections />
+                </CommandExpressionAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </WhileStatementAst>
+      <PipelineAst>
+        <PipelineElements>
+          <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="unassgn" StaticType="System.Object" />
+            </CommandElements>
+            <InvocationOperator />
+            <Redirections />
+          </CommandAst>
+        </PipelineElements>
+      </PipelineAst>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="yessub" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <ConstantExpressionAst StaticType="int">5</ConstantExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <WhileStatementAst Condition="$j -gt 0">
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ParenExpressionAst StaticType="System.Object">
+                      <PipelineAst>
+                        <PipelineElements>
+                          <CommandExpressionAst>
+                            <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
+                              <Operator />
+                              <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+                              <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
+                            </BinaryExpressionAst>
+                            <Redirections />
+                          </CommandExpressionAst>
+                        </PipelineElements>
+                      </PipelineAst>
+                    </ParenExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ParenExpressionAst StaticType="System.Object">
+                      <PipelineAst>
+                        <PipelineElements>
+                          <CommandExpressionAst>
+                            <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
+                              <Operator />
+                              <VariableExpressionAst VariablePath="yessub" StaticType="System.Object" />
+                              <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+                            </BinaryExpressionAst>
+                            <Redirections />
+                          </CommandExpressionAst>
+                        </PipelineElements>
+                      </PipelineAst>
+                    </ParenExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandExpressionAst>
+                  <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                    <TokenKind />
+                    <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+                  </UnaryExpressionAst>
+                  <Redirections />
+                </CommandExpressionAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <VariableExpressionAst VariablePath="j" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </WhileStatementAst>
+      <AssignmentStatementAst Operator="Equals">
+        <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
+        <Operator />
+        <CommandExpressionAst>
+          <BinaryExpressionAst Operator="Minus" StaticType="System.Object">
+            <Operator />
+            <VariableExpressionAst VariablePath="nothere" StaticType="System.Object" />
+            <ConstantExpressionAst StaticType="int">5</ConstantExpressionAst>
+          </BinaryExpressionAst>
+          <Redirections />
+        </CommandExpressionAst>
+      </AssignmentStatementAst>
+      <PipelineAst>
+        <PipelineElements>
+          <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
+            </CommandElements>
+            <InvocationOperator />
+            <Redirections />
+          </CommandAst>
+        </PipelineElements>
+      </PipelineAst>
+      <IfStatementAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <ConstantExpressionAst StaticType="int">5</ConstantExpressionAst>
+                <ConstantExpressionAst StaticType="int">6</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+      </IfStatementAst>
+      <IfStatementAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <ConstantExpressionAst StaticType="int">5</ConstantExpressionAst>
+                <ConstantExpressionAst StaticType="int">6</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <ConstantExpressionAst StaticType="int">6</ConstantExpressionAst>
+                <ConstantExpressionAst StaticType="int">7</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">hi<StringConstantType /></StringConstantExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+      </IfStatementAst>
+    </Statements>
+  </NamedBlockAst>
+</ScriptBlockAst>

--- a/data/basics/test_for.deob.ps1
+++ b/data/basics/test_for.deob.ps1
@@ -7,15 +7,30 @@ for ($i = 0; $i -lt 3; $i--)
 for ($i = 0; ; $i++)
 {
    Write-Host $i;
-   break;
+   if ($i -eq 4)
+   {
+      break;
+   }
 }
 
 for ($i = 0; $i -lt 3; )
 {
-   Write-Host $i++;
+   Write-Host ($i++);
+}
+
+for (; $i -lt 4; $i++)
+{
+   Write-Host $i;
 }
 
 for (; ; )
 {
-   break;
+   if ($i -eq 3)
+   {
+      break;
+   }
 }
+$y = 4;
+Write-Host $y;
+$z = Get-Command Get-Process;
+Write-Host $z.CommandType;

--- a/data/basics/test_for.deob.xml
+++ b/data/basics/test_for.deob.xml
@@ -1,119 +1,174 @@
 <ScriptBlockAst>
-  <UsingStatements/>
+  <UsingStatements />
   <NamedBlockAst>
     <Statements>
       <ForStatementAst Condition="$i -lt 3">
         <AssignmentStatementAst Operator="Equals">
-          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
           <CommandExpressionAst>
             <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
             </CommandExpressionAst>
         </AssignmentStatementAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
+        <CommandExpressionAst>
               <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
-                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
               </UnaryExpressionAst>
               </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-        <StatementBlockAst>
+          <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
-                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
+        <CommandExpressionAst>
               <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
-                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                 <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
               </BinaryExpressionAst>
               </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-      </ForStatementAst>
+          </ForStatementAst>
       <ForStatementAst Condition="">
         <AssignmentStatementAst Operator="Equals">
-          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
           <CommandExpressionAst>
             <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
             </CommandExpressionAst>
         </AssignmentStatementAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
+        <CommandExpressionAst>
               <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
-                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
               </UnaryExpressionAst>
               </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-        <StatementBlockAst>
+          <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
-                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-            <BreakStatementAst/>
+              <IfStatementAst>
+              <CommandExpressionAst>
+                    <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                      <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                      <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+                    </BinaryExpressionAst>
+                    </CommandExpressionAst>
+                <StatementBlockAst>
+                <Statements>
+                  <BreakStatementAst />
+                </Statements>
+              </StatementBlockAst>
+            </IfStatementAst>
           </Statements>
         </StatementBlockAst>
       </ForStatementAst>
       <ForStatementAst Condition="$i -lt 3">
         <AssignmentStatementAst Operator="Equals">
-          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
           <CommandExpressionAst>
             <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
             </CommandExpressionAst>
         </AssignmentStatementAst>
         <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
-                    <ExpandableStringExpressionAst StringConstantType="BareWord" StaticType="string">$i++<StringConstantType/><NestedExpressions><VariableExpressionAst VariablePath="i" StaticType="System.Object"/></NestedExpressions></ExpandableStringExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ParenExpressionAst StaticType="System.Object">
+                      <CommandExpressionAst>
+                            <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                              <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                            </UnaryExpressionAst>
+                            </CommandExpressionAst>
+                        </ParenExpressionAst>
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
+        <CommandExpressionAst>
               <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
-                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                 <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
               </BinaryExpressionAst>
               </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-      </ForStatementAst>
+          </ForStatementAst>
+      <ForStatementAst Condition="$i -lt 4">
+        <CommandExpressionAst>
+              <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+              </UnaryExpressionAst>
+              </CommandExpressionAst>
+          <StatementBlockAst>
+          <Statements>
+            <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </CommandElements>
+                  </CommandAst>
+              </Statements>
+        </StatementBlockAst>
+        <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              </CommandExpressionAst>
+          </ForStatementAst>
       <ForStatementAst Condition="">
         <StatementBlockAst>
           <Statements>
-            <BreakStatementAst/>
+            <IfStatementAst>
+              <CommandExpressionAst>
+                    <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                      <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                      <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
+                    </BinaryExpressionAst>
+                    </CommandExpressionAst>
+                <StatementBlockAst>
+                <Statements>
+                  <BreakStatementAst />
+                </Statements>
+              </StatementBlockAst>
+            </IfStatementAst>
           </Statements>
         </StatementBlockAst>
       </ForStatementAst>
-    </Statements>
+      <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="y" StaticType="System.Object" />
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+            </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="y" StaticType="System.Object" />
+            </CommandElements>
+            </CommandAst>
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="z" StaticType="System.Object" />
+          <CommandAst>
+                <CommandElements>
+                  <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Get-Command<StringConstantType /></StringConstantExpressionAst>
+                  <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Get-Process<StringConstantType /></StringConstantExpressionAst>
+                </CommandElements>
+                </CommandAst>
+            </AssignmentStatementAst>
+        <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <MemberExpressionAst Static="False" StaticType="System.Object">
+                      <VariableExpressionAst VariablePath="z" StaticType="System.Object" />
+                      <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">CommandType<StringConstantType /></StringConstantExpressionAst>
+                    </MemberExpressionAst>
+                  </CommandElements>
+                  </CommandAst>
+              </Statements>
   </NamedBlockAst>
 </ScriptBlockAst>

--- a/data/basics/test_for.ps1
+++ b/data/basics/test_for.ps1
@@ -6,13 +6,38 @@ for ($i = 0; $i -lt 3; $i--) {
 # [0] assignment, [1] update (PipelineAst), [2] block
 for ($i = 0; ; $i++) {
   Write-Host $i
-  break
+  if ($i -eq 4) {
+    break
+  }
 }
 # [0] assignment, [1] block, [2] cond (PipelineAst)
 for ($i = 0; $i -lt 3;) {
-  Write-Host $i++
+  Write-Host ($i++)
+}
+# [0] update, [1] block, [2] cond
+for (; $i -lt 4; $i++) {
+  Write-Host $i
 }
 # [0] block
 for (; ;) {
+  if ($i -eq 3) {
+    break
+  }
+}
+
+# Dead
+for ($x = 0; $x -gt 4; $x--) {
+  Write-Host $x
+}
+
+# Dead, but loop var has usage
+for ($y = 4; $y -lt 3; $y--) {
+  Write-Host $y+1
+}
+Write-Host $y
+
+# Lift Write-Host to top
+for ($z = Get-Command Get-Process;;) {
+  Write-Host $z.CommandType
   break
 }

--- a/data/basics/test_for.xml
+++ b/data/basics/test_for.xml
@@ -88,7 +88,25 @@
                 </CommandAst>
               </PipelineElements>
             </PipelineAst>
-            <BreakStatementAst />
+            <IfStatementAst>
+              <PipelineAst>
+                <PipelineElements>
+                  <CommandExpressionAst>
+                    <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                      <Operator />
+                      <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                      <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+                    </BinaryExpressionAst>
+                    <Redirections />
+                  </CommandExpressionAst>
+                </PipelineElements>
+              </PipelineAst>
+              <StatementBlockAst>
+                <Statements>
+                  <BreakStatementAst />
+                </Statements>
+              </StatementBlockAst>
+            </IfStatementAst>
           </Statements>
         </StatementBlockAst>
       </ForStatementAst>
@@ -108,7 +126,19 @@
                 <CommandAst>
                   <CommandElements>
                     <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
-                    <ExpandableStringExpressionAst StringConstantType="BareWord" StaticType="string">$i++<StringConstantType /><NestedExpressions><VariableExpressionAst VariablePath="i" StaticType="System.Object" /></NestedExpressions></ExpandableStringExpressionAst>
+                    <ParenExpressionAst StaticType="System.Object">
+                      <PipelineAst>
+                        <PipelineElements>
+                          <CommandExpressionAst>
+                            <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                              <TokenKind />
+                              <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                            </UnaryExpressionAst>
+                            <Redirections />
+                          </CommandExpressionAst>
+                        </PipelineElements>
+                      </PipelineAst>
+                    </ParenExpressionAst>
                   </CommandElements>
                   <InvocationOperator />
                   <Redirections />
@@ -130,9 +160,216 @@
           </PipelineElements>
         </PipelineAst>
       </ForStatementAst>
+      <ForStatementAst Condition="$i -lt 4">
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
+                <TokenKind />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+              </UnaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                <Operator />
+                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </ForStatementAst>
       <ForStatementAst Condition="">
         <StatementBlockAst>
           <Statements>
+            <IfStatementAst>
+              <PipelineAst>
+                <PipelineElements>
+                  <CommandExpressionAst>
+                    <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                      <Operator />
+                      <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
+                      <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
+                    </BinaryExpressionAst>
+                    <Redirections />
+                  </CommandExpressionAst>
+                </PipelineElements>
+              </PipelineAst>
+              <StatementBlockAst>
+                <Statements>
+                  <BreakStatementAst />
+                </Statements>
+              </StatementBlockAst>
+            </IfStatementAst>
+          </Statements>
+        </StatementBlockAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="$x -gt 4">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="x" StaticType="System.Object" />
+          <Operator />
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
+            <Redirections />
+          </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                <TokenKind />
+                <VariableExpressionAst VariablePath="x" StaticType="System.Object" />
+              </UnaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="x" StaticType="System.Object" />
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
+                <Operator />
+                <VariableExpressionAst VariablePath="x" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </ForStatementAst>
+      <ForStatementAst Condition="$y -lt 3">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="y" StaticType="System.Object" />
+          <Operator />
+          <CommandExpressionAst>
+            <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
+            <Redirections />
+          </CommandExpressionAst>
+        </AssignmentStatementAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
+                <TokenKind />
+                <VariableExpressionAst VariablePath="y" StaticType="System.Object" />
+              </UnaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <ExpandableStringExpressionAst StringConstantType="BareWord" StaticType="string">$y+1<StringConstantType /><NestedExpressions><VariableExpressionAst VariablePath="y" StaticType="System.Object" /></NestedExpressions></ExpandableStringExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
+          </Statements>
+        </StatementBlockAst>
+        <PipelineAst>
+          <PipelineElements>
+            <CommandExpressionAst>
+              <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
+                <Operator />
+                <VariableExpressionAst VariablePath="y" StaticType="System.Object" />
+                <ConstantExpressionAst StaticType="int">3</ConstantExpressionAst>
+              </BinaryExpressionAst>
+              <Redirections />
+            </CommandExpressionAst>
+          </PipelineElements>
+        </PipelineAst>
+      </ForStatementAst>
+      <PipelineAst>
+        <PipelineElements>
+          <CommandAst>
+            <CommandElements>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="y" StaticType="System.Object" />
+            </CommandElements>
+            <InvocationOperator />
+            <Redirections />
+          </CommandAst>
+        </PipelineElements>
+      </PipelineAst>
+      <ForStatementAst Condition="">
+        <AssignmentStatementAst Operator="Equals">
+          <VariableExpressionAst VariablePath="z" StaticType="System.Object" />
+          <Operator />
+          <PipelineAst>
+            <PipelineElements>
+              <CommandAst>
+                <CommandElements>
+                  <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Get-Command<StringConstantType /></StringConstantExpressionAst>
+                  <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Get-Process<StringConstantType /></StringConstantExpressionAst>
+                </CommandElements>
+                <InvocationOperator />
+                <Redirections />
+              </CommandAst>
+            </PipelineElements>
+          </PipelineAst>
+        </AssignmentStatementAst>
+        <StatementBlockAst>
+          <Statements>
+            <PipelineAst>
+              <PipelineElements>
+                <CommandAst>
+                  <CommandElements>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <MemberExpressionAst Static="False" StaticType="System.Object">
+                      <VariableExpressionAst VariablePath="z" StaticType="System.Object" />
+                      <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">CommandType<StringConstantType /></StringConstantExpressionAst>
+                    </MemberExpressionAst>
+                  </CommandElements>
+                  <InvocationOperator />
+                  <Redirections />
+                </CommandAst>
+              </PipelineElements>
+            </PipelineAst>
             <BreakStatementAst />
           </Statements>
         </StatementBlockAst>

--- a/data/basics/test_sub_expression.deob.ps1
+++ b/data/basics/test_sub_expression.deob.ps1
@@ -1,6 +1,6 @@
 $a = @(0, 1, 2);
 $foo = $(   
-   for($i = 0;$i -lt $a.Length;$i++)
+   for ($i = 0; $i -lt $a.Length; $i++)
    {
       $a[$i] + 1;
    }

--- a/data/basics/test_sub_expression.deob.xml
+++ b/data/basics/test_sub_expression.deob.xml
@@ -1,9 +1,9 @@
 <ScriptBlockAst>
-  <UsingStatements/>
+  <UsingStatements />
   <NamedBlockAst>
     <Statements>
       <AssignmentStatementAst Operator="Equals">
-        <VariableExpressionAst VariablePath="a" StaticType="System.Object"/>
+        <VariableExpressionAst VariablePath="a" StaticType="System.Object" />
         <CommandExpressionAst>
           <ArrayLiteralAst StaticType="System.Object[]">
             <Elements>
@@ -15,80 +15,60 @@
           </CommandExpressionAst>
       </AssignmentStatementAst>
       <AssignmentStatementAst Operator="Equals">
-        <VariableExpressionAst VariablePath="foo" StaticType="System.Object"/>
+        <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
         <CommandExpressionAst>
           <SubExpressionAst StaticType="System.Object">
             <StatementBlockAst>
               <Statements>
                 <ForStatementAst Condition="$i -lt $a.Length">
                   <AssignmentStatementAst Operator="Equals">
-                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                     <CommandExpressionAst>
                       <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
                       </CommandExpressionAst>
                   </AssignmentStatementAst>
-                  <PipelineAst>
-                    <PipelineElements>
-                      <CommandExpressionAst>
+                  <CommandExpressionAst>
                         <UnaryExpressionAst TokenKind="PostfixPlusPlus" StaticType="System.Object">
-                          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                         </UnaryExpressionAst>
                         </CommandExpressionAst>
-                    </PipelineElements>
-                  </PipelineAst>
-                  <StatementBlockAst>
+                    <StatementBlockAst>
                     <Statements>
-                      <PipelineAst>
-                        <PipelineElements>
-                          <CommandExpressionAst>
+                      <CommandExpressionAst>
                             <BinaryExpressionAst Operator="Plus" StaticType="System.Object">
                               <IndexExpressionAst StaticType="System.Object">
-                                <VariableExpressionAst VariablePath="a" StaticType="System.Object"/>
-                                <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                                <VariableExpressionAst VariablePath="a" StaticType="System.Object" />
+                                <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                               </IndexExpressionAst>
                               <ConstantExpressionAst StaticType="int">1</ConstantExpressionAst>
                             </BinaryExpressionAst>
                             </CommandExpressionAst>
-                        </PipelineElements>
-                      </PipelineAst>
-                    </Statements>
+                        </Statements>
                   </StatementBlockAst>
-                  <PipelineAst>
-                    <PipelineElements>
-                      <CommandExpressionAst>
+                  <CommandExpressionAst>
                         <BinaryExpressionAst Operator="Ilt" StaticType="System.Object">
-                          <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                          <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                           <MemberExpressionAst Static="False" StaticType="System.Object">
-                            <VariableExpressionAst VariablePath="a" StaticType="System.Object"/>
-                            <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Length<StringConstantType/></StringConstantExpressionAst>
+                            <VariableExpressionAst VariablePath="a" StaticType="System.Object" />
+                            <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Length<StringConstantType /></StringConstantExpressionAst>
                           </MemberExpressionAst>
                         </BinaryExpressionAst>
                         </CommandExpressionAst>
-                    </PipelineElements>
-                  </PipelineAst>
-                </ForStatementAst>
-                <PipelineAst>
-                  <PipelineElements>
-                    <CommandExpressionAst>
+                    </ForStatementAst>
+                <CommandExpressionAst>
                       <ConstantExpressionAst StaticType="int">4</ConstantExpressionAst>
                       </CommandExpressionAst>
-                  </PipelineElements>
-                </PipelineAst>
-              </Statements>
+                  </Statements>
             </StatementBlockAst>
           </SubExpressionAst>
           </CommandExpressionAst>
       </AssignmentStatementAst>
-      <PipelineAst>
-        <PipelineElements>
-          <CommandAst>
+      <CommandAst>
             <CommandElements>
-              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
-              <VariableExpressionAst VariablePath="foo" StaticType="System.Object"/>
+              <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+              <VariableExpressionAst VariablePath="foo" StaticType="System.Object" />
             </CommandElements>
             </CommandAst>
-        </PipelineElements>
-      </PipelineAst>
-    </Statements>
+        </Statements>
   </NamedBlockAst>
 </ScriptBlockAst>

--- a/data/basics/test_switch_statement.deob.ps1
+++ b/data/basics/test_switch_statement.deob.ps1
@@ -13,8 +13,4 @@ switch ($variable) {
       Write-Output "Default Option";
    }
 }
-switch ($variable) {
-   default {
-      Write-Output "Default Option";
-   }
-}
+Write-Output "Default Option";

--- a/data/basics/test_switch_statement.deob.xml
+++ b/data/basics/test_switch_statement.deob.xml
@@ -1,104 +1,67 @@
 <ScriptBlockAst>
-  <UsingStatements/>
+  <UsingStatements />
   <NamedBlockAst>
     <Statements>
       <AssignmentStatementAst Operator="Equals">
-        <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+        <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
         <CommandExpressionAst>
-          <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType/></StringConstantExpressionAst>
+          <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType /></StringConstantExpressionAst>
           </CommandExpressionAst>
       </AssignmentStatementAst>
       <SwitchStatementAst Flags="None" Condition="$variable">
-        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option1<StringConstantType/></StringConstantExpressionAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option1<StringConstantType /></StringConstantExpressionAst>
         <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
-                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 1<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 1<StringConstantType /></StringConstantExpressionAst>
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
-        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType/></StringConstantExpressionAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option2<StringConstantType /></StringConstantExpressionAst>
         <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
-                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 2<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 2<StringConstantType /></StringConstantExpressionAst>
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
-        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option3<StringConstantType/></StringConstantExpressionAst>
+        <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Option3<StringConstantType /></StringConstantExpressionAst>
         <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
-                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 3<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Selected Option 3<StringConstantType /></StringConstantExpressionAst>
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
         <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
-                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType /></StringConstantExpressionAst>
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
-              <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
+        <CommandExpressionAst>
+              <VariableExpressionAst VariablePath="variable" StaticType="System.Object" />
               </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-      </SwitchStatementAst>
-      <SwitchStatementAst Flags="None" Condition="$variable">
-        <StatementBlockAst>
-          <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+          </SwitchStatementAst>
+      <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType/></StringConstantExpressionAst>
-                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType/></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Output<StringConstantType /></StringConstantExpressionAst>
+                    <StringConstantExpressionAst StringConstantType="DoubleQuoted" StaticType="string">Default Option<StringConstantType /></StringConstantExpressionAst>
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
-        </StatementBlockAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
-              <VariableExpressionAst VariablePath="variable" StaticType="System.Object"/>
-              </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-      </SwitchStatementAst>
-    </Statements>
+              </Statements>
   </NamedBlockAst>
 </ScriptBlockAst>

--- a/data/basics/test_while.deob.xml
+++ b/data/basics/test_while.deob.xml
@@ -1,9 +1,9 @@
 <ScriptBlockAst>
-  <UsingStatements/>
+  <UsingStatements />
   <NamedBlockAst>
     <Statements>
       <AssignmentStatementAst Operator="Equals">
-        <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+        <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
         <CommandExpressionAst>
           <ConstantExpressionAst StaticType="int">2</ConstantExpressionAst>
           </CommandExpressionAst>
@@ -11,31 +11,23 @@
       <WhileStatementAst Condition="$i-- -gt 0">
         <StatementBlockAst>
           <Statements>
-            <PipelineAst>
-              <PipelineElements>
-                <CommandAst>
+            <CommandAst>
                   <CommandElements>
-                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType/></StringConstantExpressionAst>
-                    <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                    <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">Write-Host<StringConstantType /></StringConstantExpressionAst>
+                    <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                   </CommandElements>
                   </CommandAst>
-              </PipelineElements>
-            </PipelineAst>
-          </Statements>
+              </Statements>
         </StatementBlockAst>
-        <PipelineAst>
-          <PipelineElements>
-            <CommandExpressionAst>
+        <CommandExpressionAst>
               <BinaryExpressionAst Operator="Igt" StaticType="System.Object">
                 <UnaryExpressionAst TokenKind="PostfixMinusMinus" StaticType="System.Object">
-                  <VariableExpressionAst VariablePath="i" StaticType="System.Object"/>
+                  <VariableExpressionAst VariablePath="i" StaticType="System.Object" />
                 </UnaryExpressionAst>
                 <ConstantExpressionAst StaticType="int">0</ConstantExpressionAst>
               </BinaryExpressionAst>
               </CommandExpressionAst>
-          </PipelineElements>
-        </PipelineAst>
-      </WhileStatementAst>
+          </WhileStatementAst>
     </Statements>
   </NamedBlockAst>
 </ScriptBlockAst>

--- a/data/scripts/git_134.deob.xml
+++ b/data/scripts/git_134.deob.xml
@@ -502,7 +502,8 @@
                                           <NamedBlockAst>
                                             <Statements>
                                               <CommandExpressionAst>
-                                                    <InvokeMemberExpressionAst Static="False" StaticType="System.Object">
+                                                    <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                                                      <InvokeMemberExpressionAst Static="False" StaticType="System.Object">
                                                         <Arguments>
                                                           <StringConstantExpressionAst StringConstantType="SingleQuoted" StaticType="string">d</StringConstantExpressionAst>
                                                         </Arguments>
@@ -512,7 +513,9 @@
                                                         </MemberExpressionAst>
                                                         <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">StartsWith</StringConstantExpressionAst>
                                                       </InvokeMemberExpressionAst>
-                                                      </CommandExpressionAst>
+                                                      <VariableExpressionAst VariablePath="False" StaticType="System.Object" />
+                                                    </BinaryExpressionAst>
+                                                    </CommandExpressionAst>
                                                 </Statements>
                                           </NamedBlockAst>
                                         </ScriptBlockAst>
@@ -700,7 +703,8 @@
                                           <NamedBlockAst>
                                             <Statements>
                                               <CommandExpressionAst>
-                                                    <InvokeMemberExpressionAst Static="False" StaticType="System.Object">
+                                                    <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                                                      <InvokeMemberExpressionAst Static="False" StaticType="System.Object">
                                                         <Arguments>
                                                           <StringConstantExpressionAst StringConstantType="SingleQuoted" StaticType="string">d</StringConstantExpressionAst>
                                                         </Arguments>
@@ -710,7 +714,9 @@
                                                         </MemberExpressionAst>
                                                         <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">StartsWith</StringConstantExpressionAst>
                                                       </InvokeMemberExpressionAst>
-                                                      </CommandExpressionAst>
+                                                      <VariableExpressionAst VariablePath="False" StaticType="System.Object" />
+                                                    </BinaryExpressionAst>
+                                                    </CommandExpressionAst>
                                                 </Statements>
                                           </NamedBlockAst>
                                         </ScriptBlockAst>
@@ -1310,11 +1316,14 @@
                                                                         <NamedBlockAst>
                                                                           <Statements>
                                                                             <CommandExpressionAst>
-                                                                                  <MemberExpressionAst Static="False" StaticType="System.Object">
+                                                                                  <BinaryExpressionAst Operator="Ieq" StaticType="System.Object">
+                                                                                    <MemberExpressionAst Static="False" StaticType="System.Object">
                                                                                       <VariableExpressionAst VariablePath="_" StaticType="System.Object" />
                                                                                       <StringConstantExpressionAst StringConstantType="BareWord" StaticType="string">DisplayName</StringConstantExpressionAst>
                                                                                     </MemberExpressionAst>
-                                                                                    </CommandExpressionAst>
+                                                                                    <VariableExpressionAst VariablePath="ServiceName" StaticType="System.Object" />
+                                                                                  </BinaryExpressionAst>
+                                                                                  </CommandExpressionAst>
                                                                               </Statements>
                                                                         </NamedBlockAst>
                                                                       </ScriptBlockAst>
@@ -1722,7 +1731,7 @@
 -------------------------------------
 </StringConstantExpressionAst>
                             </CommandExpressionAst>
-                        <ForEachStatementAst Variable="$Adapter" Condition="(Get-WmiObject -class win32_networkadapter -Filter &quot;NetConnectionStatus='2'&quot;)">
+                        <ForEachStatementAst Variable="$Adapter" Flags="None" Condition="(Get-WmiObject -class win32_networkadapter -Filter &quot;NetConnectionStatus='2'&quot;)">
                         <VariableExpressionAst VariablePath="Adapter" StaticType="System.Object" />
                         <StatementBlockAst>
                           <Statements>

--- a/data/scripts/git_134.xml
+++ b/data/scripts/git_134.xml
@@ -2356,7 +2356,7 @@
                           </CommandExpressionAst>
                         </PipelineElements>
                       </PipelineAst>
-                      <ForEachStatementAst Variable="$Adapter" Condition="(Get-WmiObject -class win32_networkadapter -Filter &quot;NetConnectionStatus='2'&quot;)">
+                      <ForEachStatementAst Variable="$Adapter" Flags="None" Condition="(Get-WmiObject -class win32_networkadapter -Filter &quot;NetConnectionStatus='2'&quot;)">
                         <VariableExpressionAst VariablePath="Adapter" StaticType="System.Object" />
                         <StatementBlockAst>
                           <Statements>

--- a/modules/operators.py
+++ b/modules/operators.py
@@ -24,3 +24,20 @@ OPS = {
     "Or": " -or ",
     "DotDot": "..",
 }
+
+
+def do_const_comparison(a, b, operator):
+    if operator == "Ieq":
+        return a == b
+    elif operator == "Ine":
+        return a != b
+    elif operator == "Ige":
+        return a >= b
+    elif operator == "Igt":
+        return a > b
+    elif operator == "Ile":
+        return a <= b
+    elif operator == "Ilt":
+        return a < b
+
+    return None

--- a/modules/optimizations/dead_codes.py
+++ b/modules/optimizations/dead_codes.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from modules.logger import log_debug, log_err
+from modules.operators import do_const_comparison
 from modules.utils import create_constant_number, parent_map, replace_node, \
     is_prefixed_var, get_used_vars, to_numeric
 
@@ -85,6 +86,201 @@ def opt_remove_uninitialised_variable_usage(ast):
                             continue
 
                         log_debug("Remove unassigned variable use '%s'" % (variable.attrib["VariablePath"]))
+
+    if kill_list or replacements:
+        parents = parent_map(ast)
+
+    for node in kill_list:
+        parents[node].remove(node)
+
+    for node, repl in replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(kill_list) + len(replacements) != 0
+
+
+def opt_remove_dead_switch_cases(ast):
+    """
+    Cuts 27 and 28 from
+    switch (48) {
+        27 { ... }
+        28 { ... }
+        ($foo + 4) { ... }
+        default { ... }
+    }
+    """
+    kill_list = []
+    replacements = []
+
+    for node in ast.iter():
+        if node.tag == "SwitchStatementAst":
+            switch_expr = node[-1]
+            if switch_expr.tag != "CommandExpressionAst" or \
+               switch_expr[0].tag not in ["ConstantExpressionAst", "StringConstantExpressionAst"]:
+                continue
+
+            switch_val = switch_expr[0].text
+            kill_counter = 0
+
+            label = block = None
+            for i, subnode in enumerate(node[:-1]):
+                if i > 0 and subnode.tag == "StatementBlockAst" and node[i - 1].tag != "StatementBlockAst":
+                    label = node[i - 1]
+                    block = subnode
+
+                    if label.tag in ["ConstantExpressionAst", "StringConstantExpressionAst"]:
+                        if label.text != switch_val:
+                            kill_list.extend((label, block))
+                            kill_counter += 2
+                        elif label.text == switch_val and block[0].tag == "Statements":
+                            # We found a matching case.
+                            replacements.append((node, list(block[0])))
+                            break
+
+            # If we removed everything except the switch expr, the switch itself needs to go.
+            if kill_counter == len(node) - 1:
+                kill_list.append(node)
+
+    if kill_list or replacements:
+        parents = parent_map(ast)
+
+    for node in kill_list:
+        parents[node].remove(node)
+
+    for node, repl in replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(kill_list) + len(replacements) != 0
+
+
+def _get_const_binary_expression_result(node):
+    if node.tag == "CommandExpressionAst" and node[0].tag == "BinaryExpressionAst":
+        bin_expr = node[0]
+        if bin_expr[0].tag == "ConstantExpressionAst" and bin_expr[1].tag == "ConstantExpressionAst":
+            a = to_numeric(bin_expr[0].text)
+            b = to_numeric(bin_expr[1].text)
+            return do_const_comparison(a, b, bin_expr.attrib["Operator"])
+        
+    return None
+
+
+def opt_remove_dead_loops(ast):
+    kill_list = []
+    replacements = []
+
+    for node in ast.iter():
+        if node.tag == "ForStatementAst":
+            # Eliminate statements like "for ($x = 0; $x -gt 4; $x++) {}".
+            # Keep the initial assignment since that could potentially be accessed elsewhere.
+            subnodes = list(node)
+            assign = subnodes[0]
+            if assign.tag != "AssignmentStatementAst" or assign.attrib["Operator"] != "Equals":
+                continue
+
+            if assign[0].tag != "VariableExpressionAst" or assign[1].tag != "CommandExpressionAst":
+                continue
+
+            if assign[1][0].tag != "ConstantExpressionAst":
+                continue
+            
+            cond = subnodes[-1]
+            if cond.tag != "CommandExpressionAst" or cond[0].tag != "BinaryExpressionAst":
+                continue
+
+            bin_expr = cond[0]
+
+            var_name = assign[0].attrib["VariablePath"].lower()
+            var_val = to_numeric(assign[1][0].text)
+            operator = bin_expr.attrib["Operator"]
+
+            # Check for form "$x OP const" or "const OP $x".
+            if bin_expr[0].tag == "VariableExpressionAst" and bin_expr[1].tag == "ConstantExpressionAst":
+                if bin_expr[0].attrib["VariablePath"].lower() != var_name:
+                    continue
+
+                cmp_val = to_numeric(bin_expr[1].text)
+                cmp_res = do_const_comparison(var_val, cmp_val, operator)
+            elif bin_expr[0].tag == "ConstantExpressionAst" and bin_expr[1].tag == "VariableExpressionAst":
+                if bin_expr[1].attrib["VariablePath"].lower() != var_name:
+                    continue
+
+                cmp_val = to_numeric(bin_expr[0].text)
+                cmp_res = do_const_comparison(cmp_val, var_val, operator)
+            else:
+                continue
+
+            if cmp_res is not None and not cmp_res:
+                log_debug(f"Remove dead For loop '{node.attrib['Condition']}'")
+
+                replacements.append((node, assign))
+
+        elif node.tag == "WhileStatementAst":
+            # Eliminate While statements that cannot be entered (e.g., "65 -gt 100").
+            cond = node[1]
+            if cond.tag != "CommandExpressionAst" or cond[0].tag != "BinaryExpressionAst":
+                continue
+
+            bin_expr = cond[0]
+            if bin_expr[0].tag == "ConstantExpressionAst" and bin_expr[1].tag == "ConstantExpressionAst":
+                a = to_numeric(bin_expr[0].text)
+                b = to_numeric(bin_expr[1].text)
+                cmp_res = do_const_comparison(a, b, bin_expr.attrib["Operator"])
+
+                if cmp_res is not None and not cmp_res:
+                    log_debug(f"Remove dead While loop '{node.attrib['Condition']}'")
+
+                    kill_list.append(node)
+
+    if kill_list or replacements:
+        parents = parent_map(ast)
+
+    for node in kill_list:
+        parents[node].remove(node)
+
+    for node, repl in replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(kill_list) + len(replacements) != 0
+
+
+def opt_remove_dead_if_clauses(ast):
+    kill_list = []
+    replacements = []
+
+    for node in ast.iter():
+        if node.tag == "IfStatementAst":
+            first_cond = node[0]
+            first_block = node[1]
+
+            cmp_res = _get_const_binary_expression_result(first_cond)
+            if cmp_res is not None and cmp_res:
+                # The If is always entered, so replace it with the contents of the first block.
+                if first_block.tag == "StatementBlockAst" and first_block[0].tag == "Statements":
+                    replacements.append((node, list(first_block[0])))
+                    continue
+
+            # Hunt for clauses with false conditions and strip them.
+            kill_counter = 0
+            for i in range(0, len(node), 2):
+                if node[i].tag == "StatementBlockAst":
+                    break
+
+                cmp_res = _get_const_binary_expression_result(node[i])
+                if cmp_res is not None and not cmp_res:
+                    kill_list.extend((node[i], node[i + 1]))
+                    kill_counter += 2
+
+            if kill_counter == len(node) - 1:
+                # Only the "else {}" remains, so lift its contents or we'll have an invalid AST.
+                if node[-1].tag == "StatementBlockAst" and node[-1][0].tag == "Statements":
+                    replacements.append((node, list(node[-1][0])))
+                else:
+                    log_err("Got only an else clause left, but structure was unknown")
+                    return False
+
+            elif kill_counter == len(node):
+                # All conditions False, without else -> entire If gone.
+                kill_list.append(node)
 
     if kill_list or replacements:
         parents = parent_map(ast)

--- a/modules/optimizations/dead_codes.py
+++ b/modules/optimizations/dead_codes.py
@@ -6,6 +6,7 @@ from modules.utils import parent_map, replace_node, is_prefixed_var, get_used_va
 def opt_unused_variable(ast):
     parents = parent_map(ast)
     used_vars = get_used_vars(ast)
+    kill_list = []
 
     for node in ast.iter():
         if node.tag in ["AssignmentStatementAst"]:
@@ -13,12 +14,14 @@ def opt_unused_variable(ast):
             if subnodes[0].tag == "VariableExpressionAst":
                 if subnodes[0].attrib["VariablePath"].lower() not in used_vars:
                     if not is_prefixed_var(subnodes[0].attrib["VariablePath"]):
-                        log_debug("Remove assignement of unused variable %s" % (subnodes[0].attrib["VariablePath"]))
+                        log_debug("Remove assignment of unused variable %s" % (subnodes[0].attrib["VariablePath"]))
 
-                        parents[node].remove(node)
+                        kill_list.append(node)
 
-                        return True
-    return False
+    for node in kill_list:
+        parents[node].remove(node)
+
+    return len(kill_list) != 0
 
 
 def opt_remove_uninitialised_variable_usage(ast):

--- a/modules/optimizations/dead_codes.py
+++ b/modules/optimizations/dead_codes.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-from modules.logger import log_debug
-from modules.utils import parent_map, replace_node, is_prefixed_var, get_used_vars
+from modules.logger import log_debug, log_err
+from modules.utils import create_constant_number, parent_map, replace_node, \
+    is_prefixed_var, get_used_vars, to_numeric
 
 
 def opt_unused_variable(ast):
@@ -26,14 +27,43 @@ def opt_unused_variable(ast):
 
 def opt_remove_uninitialised_variable_usage(ast):
     assigned = set()
+    kill_list = []
+    replacements = []
+
+    """
+    FIXME This function causes invalid output for constructs like
+    $i = 2;
+    while ($i -gt 0) {
+      $unassgn = $unassn + 4;
+      $i--;
+    }
+    Write-Host $unassgn
+    """
 
     for node in ast.iter():
         if node.tag in ["AssignmentStatementAst"]:
             subnodes = list(node)
+            if subnodes[1].tag == "CommandExpressionAst" and subnodes[1][0].tag == "VariableExpressionAst":
+                var_source = subnodes[1][0].attrib["VariablePath"].lower()
+                if var_source not in assigned:
+                    if not is_prefixed_var(var_source) and var_source != "_":
+                        var_dest = subnodes[0].attrib["VariablePath"].lower()
+                        log_debug(f"Remove variable '{var_dest}' assigned from unassigned variable '{var_source}'")
+                        kill_list.append(node)
+                        continue
+
             if subnodes[0].tag == "VariableExpressionAst":
                 assigned.add(subnodes[0].attrib["VariablePath"].lower())
-        if node.tag in ["BinaryExpressionAst"]:
+
+        elif node.tag in ["ParameterAst"]:
+            var_expr = node.find("VariableExpressionAst")
+            if var_expr is not None:
+                assigned.add(var_expr.attrib["VariablePath"].lower())
+
+        elif node.tag in ["BinaryExpressionAst"]:
             subnodes = list(node)
+
+            operator = node.attrib["Operator"]
 
             if subnodes[0].tag == "VariableExpressionAst":
                 variable = subnodes[0]
@@ -47,9 +77,22 @@ def opt_remove_uninitialised_variable_usage(ast):
             if variable is not None and other is not None:
                 if variable.attrib["VariablePath"].lower() not in assigned:
                     if not is_prefixed_var(variable.attrib["VariablePath"]):
+                        if operator == "Plus":
+                            replacements.append((node, other))
+                        elif operator in ["Minus", "Multiply"] and other.tag == "ConstantExpressionAst":
+                            replacements.append((variable, create_constant_number(0)))
+                        else:
+                            continue
+
                         log_debug("Remove unassigned variable use '%s'" % (variable.attrib["VariablePath"]))
-                        replace_node(ast, node, other)
 
-                        return True
+    if kill_list or replacements:
+        parents = parent_map(ast)
 
-    return False
+    for node in kill_list:
+        parents[node].remove(node)
+
+    for node, repl in replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(kill_list) + len(replacements) != 0

--- a/modules/optimizations/empty_nodes.py
+++ b/modules/optimizations/empty_nodes.py
@@ -1,18 +1,22 @@
 # coding=utf-8
-from modules.logger import log_debug
-from modules.utils import delete_node
+from modules.logger import log_info
+from modules.utils import parent_map
 
 
 def opt_remove_empty_nodes(ast):
+    parents = parent_map(ast)
+    kill_list = []
     for node in ast.iter():
         if node.tag in ("Attributes", "Redirections", "CatchTypes", \
-                        "Operator", "TokenKind", "BlockKind", "InvocationOperator"):
-            subnodes = list(node)
-            if len(subnodes) == 0:
-                log_debug(f"Remove empty node {node.tag}")
+                        "Operator", "TokenKind", "BlockKind", "InvocationOperator", \
+                        "Flags", "Clauses"):
+            if len(node) == 0:
+                kill_list.append(node)
 
-                delete_node(ast, node)
+    for node in kill_list:
+        parents[node].remove(node)
 
-                return True
+    if kill_list:
+        log_info(f"Deleted {len(kill_list)} empty nodes")
 
     return False

--- a/modules/optimizations/simplifications.py
+++ b/modules/optimizations/simplifications.py
@@ -1,10 +1,14 @@
 # coding=utf-8
 
+from xml.etree.ElementTree import Element
+
 from modules.barewords import BAREWORDS
 from modules.logger import log_debug
+from modules.scope import Scope
 from modules.special_vars import SPECIAL_VARS_NAMES
-from modules.utils import replace_node, create_constant_string, get_array_literal_values, create_array_literal_values, \
-    get_used_vars
+from modules.utils import (create_array_literal_values, create_constant_number,
+                           create_constant_string, get_array_literal_values, get_assigned_vars,
+                           parent_map, replace_node, to_numeric)
 
 
 def opt_command_element_as_bareword(ast):
@@ -210,53 +214,196 @@ def opt_prefixed_variable_case(ast):
     return False
 
 
-def opt_replace_constant_variable_by_value(ast):
-    cst_assigned = dict()
+class ConstantPropagator:
 
-    used_vars = get_used_vars(ast)
+    def __init__(self):
+        self._scope = Scope()
+        self._loop_assigned = None
+        self.replacements = []
 
-    for node in ast.iter():
-        if node.tag in ["AssignmentStatementAst"]:
+    def _replace_var(self, parent_node, var_expression):
+        var_name = var_expression.attrib["VariablePath"].lower()
+        if self._loop_assigned is not None and var_name in self._loop_assigned:
+            # Variable is touched in a loop, so we can't arrive
+            # at any conclusion without a more complicated analysis.
+            return
+
+        value = self._scope.get_var(var_name)
+        if value is not None:
+            if isinstance(value, str):
+                new_element = create_constant_string(value,
+                                                     "BareWord" if parent_node.tag == "InvokeMemberExpressionAst"
+                                                     else "DoubleQuoted")
+
+                log_debug("Replace constant variable %s (string) in expression" % (
+                    var_expression.attrib["VariablePath"]))
+
+                self.replacements.append((var_expression, new_element))
+
+            elif isinstance(value, (int, float)):
+                new_element = create_constant_number(value)
+                log_debug("Replace constant variable %s (number) in expression" % (
+                    var_expression.attrib["VariablePath"]))
+                self.replacements.append((var_expression, new_element))
+
+            elif isinstance(value, list):
+                new_element = create_array_literal_values(value)
+                log_debug(
+                    "Replace constant variable %s (array) in expression" % (var_expression.attrib["VariablePath"]))
+                self.replacements.append((var_expression, new_element))
+
+    def propagate(self, node):
+        is_loop_tag = False
+
+        if node.tag == "StatementBlockAst":
+            self._scope.enter()
+
+        elif node.tag in ["ForStatementAst", "ForEachStatementAst", "DoWhileStatementAst", "WhileStatementAst"]:
+            if self._loop_assigned is None:
+                # Once entering any type of loop, get a set of variables the loop touches.
+                # This includes any nested loop statements, so we only get it once (until
+                # we leave the topmost-level loop).
+                self._loop_assigned = get_assigned_vars(node)
+                is_loop_tag = True
+
+        elif node.tag in ["AssignmentStatementAst"]:
             subnodes = list(node)
             if subnodes[0].tag == "VariableExpressionAst":
                 variable = subnodes[0]
                 if subnodes[1].tag == "CommandExpressionAst":
+                    var_name = variable.attrib["VariablePath"].lower()
                     subnodes = list(subnodes[1])
-                    if len(subnodes) == 1:
+                    if len(subnodes) == 1 and node.attrib["Operator"] == "Equals":
                         if subnodes[0].tag == "StringConstantExpressionAst":
-                            cst_assigned[variable.attrib["VariablePath"].lower()] = subnodes[0].text
+                            self._scope.set_var(var_name, subnodes[0].text)
+                        elif subnodes[0].tag == "ConstantExpressionAst":
+                            self._scope.set_var(var_name, to_numeric(subnodes[0].text))
                         elif subnodes[0].tag == "ArrayLiteralAst":
-                            cst_assigned[variable.attrib["VariablePath"].lower()] = get_array_literal_values(
-                                subnodes[0])
+                            self._scope.set_var(var_name, get_array_literal_values(subnodes[0]))
+                        elif subnodes[0].tag == "VariableExpressionAst":
+                            # $somevar = $var_that_is_constant;
+                            self._replace_var(node, subnodes[0])
                     else:
-                        if variable.attrib["VariablePath"].lower() in cst_assigned:
-                            del cst_assigned[variable.attrib["VariablePath"].lower()]
+                        self._scope.del_var(var_name)
 
-        if node.tag in ["UnaryExpressionAst", "BinaryExpressionAst", "Arguments", "InvokeMemberExpressionAst"]:
+        elif node.tag == "UnaryExpressionAst" and node.attrib["TokenKind"] in ["PostfixPlusPlus", "PostfixMinusMinus"]:
+            subnodes = list(node)
+            if subnodes[0].tag == "VariableExpressionAst":
+                variable = subnodes[0]
+                self._scope.del_var(variable.attrib["VariablePath"].lower())
+
+        if node.tag in ["UnaryExpressionAst", "BinaryExpressionAst", "Arguments",
+                        "InvokeMemberExpressionAst", "ConvertExpressionAst"]:
             subnodes = list(node)
             for subnode in subnodes:
                 if subnode.tag == "VariableExpressionAst":
-                    var_name = subnode.attrib["VariablePath"].lower()
-                    if var_name in cst_assigned and used_vars.setdefault(var_name, 0) == 1:
+                    self._replace_var(node, subnode)
 
-                        value = cst_assigned[var_name]
+        for subnode in node:
+            self.propagate(subnode)
 
-                        if isinstance(value, str):
-                            new_element = create_constant_string(value,
-                                                                 "BareWord" if node.tag == "InvokeMemberExpressionAst"
-                                                                 else "DoubleQuoted")
+        if is_loop_tag:
+            self._loop_assigned = None
 
-                            log_debug("Replace constant variable %s (string) in expression" % (
-                                subnode.attrib["VariablePath"]))
+        if node.tag == "StatementBlockAst":
+            self._scope.leave()
 
-                            replace_node(ast, subnode, new_element)
-                            return True
 
-                        elif isinstance(value, list):
-                            new_element = create_array_literal_values(value)
-                            log_debug(
-                                "Replace constant variable %s (array) in expression" % (subnode.attrib["VariablePath"]))
-                            replace_node(ast, subnode, new_element)
-                            return True
+def opt_replace_constant_variable_by_value(ast):
+    prop = ConstantPropagator()
+    prop.propagate(ast.getroot())
+
+    if prop.replacements:
+        parents = parent_map(ast)
+    for node, repl in prop.replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(prop.replacements) != 0
+
+
+def opt_convert_bogus_loops(ast):
+    """Turns loops with one unconditional break at the end into an if-statement."""
+
+    for node in ast.iter():
+        if node.tag == "WhileStatementAst" and len(node) == 2:
+            if node[0].tag == "StatementBlockAst" and node[0][0].tag == "Statements":
+                statements = node[0][0]
+                last_break = statements[-1]
+                if last_break.tag == "BreakStatementAst":
+                    if any(stmt.tag in ["BreakStatementAst", "ContinueStatementAst"] and stmt != last_break
+                           for stmt in statements.iter()):
+                        # There's another break/continue somewhere in the loop, so we can't convert this one.
+                        continue
+
+                    statements.remove(last_break)
+
+                    if_stmt = Element("IfStatementAst")
+                    if_stmt.append(node[1])  # Condition
+                    if_stmt.append(node[0])  # StatementBlockAst
+
+                    log_debug("Converting while-loop to if-statement")
+                    replace_node(ast, node, if_stmt)
+                    return True
+
+        elif node.tag == "ForStatementAst":
+            assign_index = 0 if node[0].tag == "AssignmentStatementAst" else -1
+            for block_index in range(assign_index + 1, 3):
+                if node[block_index].tag == "StatementBlockAst":
+                    break
+            else:
+                continue  # Shouldn't happen
+
+            statements = node[block_index][0]
+            if statements.tag != "Statements":
+                continue
+
+            last_break = statements[-1]
+            if last_break.tag == "BreakStatementAst":
+                if any(stmt.tag in ["BreakStatementAst", "ContinueStatementAst"] and stmt != last_break
+                       for stmt in statements.iter()):
+                    # There's another break/continue somewhere in the loop, so we can't convert this one.
+                    continue
+
+                statements.remove(last_break)
+
+                cond_index = block_index + 1 if len(node) > block_index + 1 else -1
+                if cond_index != -1:
+                    if_stmt = Element("IfStatementAst")
+                    if_stmt.append(node[cond_index])   # Condition
+                    if_stmt.append(node[block_index])  # StatementBlockAst
+
+                    log_debug("Converting for-loop to if-statement")
+                    if assign_index != -1:
+                        replace_node(ast, node, (node[assign_index], if_stmt))
+                    else:
+                        replace_node(ast, node, if_stmt)
+                    return True
+
+                else:
+                    log_debug("Lifting for-loop without condition")
+                    if assign_index != -1:
+                        replace_node(ast, node, [node[assign_index]] + list(statements))
+                    else:
+                        replace_node(ast, node, list(statements))
+                    return True
+
+    return False
+
+
+def opt_lift_switch_with_just_default(ast):
+    """
+    switch (<nothing-with-potential-side-effects>) {
+      default {
+        ...
+      }
+    }
+    """
+    for node in ast.iter():
+        if node.tag == "SwitchStatementAst" and len(node) == 2:
+            if node[1].tag == "CommandExpressionAst" and node[1][0].tag in \
+                    ["ConstantExpressionAst", "StringConstantExpressionAst", "VariableExpressionAst"]:
+                if node[0].tag == "StatementBlockAst" and node[0][0].tag == "Statements":
+                    replace_node(ast, node, list(node[0][0]))
+                    return True
 
     return False

--- a/modules/optimizations/simplifications.py
+++ b/modules/optimizations/simplifications.py
@@ -77,6 +77,7 @@ def opt_type_constraint_case(ast):
 
 
 def opt_simplify_paren_single_expression(ast):
+    replacements = []
     for node in ast.iter():
         if node.tag == "ParenExpressionAst":
             subnodes = list(node)
@@ -90,13 +91,18 @@ def opt_simplify_paren_single_expression(ast):
                                                               "BinaryExpressionAst"]:
                 log_debug("Replace paren with single expression by %s" % subnodes[0].tag)
 
-                replace_node(ast, node, subnodes[0])
+                replacements.append((node, subnodes[0]))
 
-                return True
-    return False
+    if replacements:
+        parents = parent_map(ast)
+    for node, repl in replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(replacements) != 0
 
 
 def opt_simplify_pipeline_single_command(ast):
+    replacements = []
     for node in ast.iter():
         if node.tag == "PipelineAst":
             subnodes = list(node)
@@ -105,10 +111,14 @@ def opt_simplify_pipeline_single_command(ast):
             if len(subnodes) == 1:
                 log_debug("Replace pipeline with single elements by %s" % subnodes[0].tag)
 
-                replace_node(ast, node, subnodes[0])
+                replacements.append((node, subnodes[0]))
 
-                return True
-    return False
+    if replacements:
+        parents = parent_map(ast)
+    for node, repl in replacements:
+        replace_node(ast, node, repl, parents=parents)
+
+    return len(replacements) != 0
 
 
 def opt_simplify_single_array(ast):

--- a/modules/optimizations/type_convertions.py
+++ b/modules/optimizations/type_convertions.py
@@ -127,3 +127,23 @@ def opt_convert_type_to_char(ast):
                     return True
 
     return False
+
+
+def opt_convert_type_to_int(ast):
+    for node in ast.iter():
+        if node.tag in ["ConvertExpressionAst"]:
+            type_name = node.find("TypeConstraintAst")
+            if type_name is not None:
+                type_name = type_name.attrib["TypeName"].lower()
+
+            if type_name == "int":
+                cst_int_node = node.find("ConstantExpressionAst")
+
+                if cst_int_node is not None and cst_int_node.attrib["StaticType"] == "int":
+                    log_debug("Remove no-op integer conversion")
+
+                    replace_node(ast, node, cst_int_node)
+
+                    return True
+
+    return False

--- a/modules/optimize.py
+++ b/modules/optimize.py
@@ -17,6 +17,8 @@ from modules.optimizations.simplifications import opt_convert_bogus_loops, opt_s
     opt_simplify_single_array, opt_simplify_pipeline_single_command, opt_type_constraint_from_convert, \
     opt_command_element_as_bareword, opt_type_constraint_case, opt_special_variable_case, \
     opt_lift_switch_with_just_default
+from modules.optimizations.type_convertions import opt_convert_type_to_int, opt_convert_type_to_type, \
+    opt_convert_type_to_char, opt_convert_type_to_array, opt_convert_type_to_string
 from modules.optimizations.unary_expressions import opt_unary_expression_join
 
 
@@ -44,9 +46,10 @@ def optimize_pass(ast, stats):
         opt_invoke_replace_string,
         opt_invoke_reverse_array,
         opt_invoke_expression,
-        # Convertion
+        # Type conversion
         opt_convert_type_to_type,
         opt_convert_type_to_string,
+        opt_convert_type_to_int,
         opt_convert_type_to_char,
         opt_convert_type_to_array,
         # Complex operations

--- a/modules/optimize.py
+++ b/modules/optimize.py
@@ -6,7 +6,8 @@ from modules.optimizations.alias import opt_alias
 from modules.optimizations.binary_expressions import opt_binary_expression_plus, opt_binary_expression_format, \
     opt_binary_expression_replace, opt_binary_expression_join, opt_binary_expression_numeric_operators
 from modules.optimizations.complex_operations import opt_value_of_const_array
-from modules.optimizations.dead_codes import opt_unused_variable, opt_remove_uninitialised_variable_usage
+from modules.optimizations.dead_codes import opt_unused_variable, opt_remove_uninitialised_variable_usage, \
+    opt_remove_dead_loops, opt_remove_dead_switch_cases, opt_remove_dead_if_clauses
 from modules.optimizations.empty_nodes import opt_remove_empty_nodes
 from modules.optimizations.invoke_member import opt_invoke_split_string, opt_invoke_replace_string, \
     opt_invoke_reverse_array, opt_invoke_expression
@@ -29,6 +30,9 @@ def optimize_pass(ast, stats):
         opt_simplify_pipeline_single_command,
         opt_simplify_single_array,
         opt_remove_uninitialised_variable_usage,
+        opt_remove_dead_switch_cases,
+        opt_remove_dead_loops,
+        opt_remove_dead_if_clauses,
         # Expressions
         opt_unary_expression_join,
         opt_binary_expression_plus,

--- a/modules/optimize.py
+++ b/modules/optimize.py
@@ -20,7 +20,7 @@ from modules.optimizations.type_convertions import opt_convert_type_to_type, opt
 from modules.optimizations.unary_expressions import opt_unary_expression_join
 
 
-def optimize_pass(ast):
+def optimize_pass(ast, stats):
     optimizations = [
         # Remove nodes
         opt_remove_empty_nodes,
@@ -62,7 +62,11 @@ def optimize_pass(ast):
     ]
 
     for opt in optimizations:
-        if opt(ast):
+        did_opt = False
+        while opt(ast):
+            stats.steps += 1
+            did_opt = True
+        if did_opt:
             return True
 
     return False
@@ -71,16 +75,16 @@ def optimize_pass(ast):
 class Optimizer:
     def __init__(self):
         self.stats = SimpleNamespace()
-        setattr(self.stats, "modifications", 0)
+        setattr(self.stats, "steps", 0)
 
     def optimize(self, ast):
         count_in = sum(1 for _ in ast.getroot().iter())
         log_debug(f"{count_in} nodes loaded")
 
-        while optimize_pass(ast):
-            self.stats.modifications += 1
+        while optimize_pass(ast, self.stats):
+            pass
 
-        log_info(f"{self.stats.modifications} modifications applied")
+        log_info(f"{self.stats.steps} optimization steps executed")
 
         count_out = sum(1 for _ in ast.getroot().iter())
         ratio = "{:02.2f}".format(count_out / count_in * 100.00)

--- a/modules/optimize.py
+++ b/modules/optimize.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from modules.logger import log_info, log_debug
 from modules.optimizations.alias import opt_alias
 from modules.optimizations.binary_expressions import opt_binary_expression_plus, opt_binary_expression_format, \
-    opt_binary_expression_replace, opt_binary_expression_join
+    opt_binary_expression_replace, opt_binary_expression_join, opt_binary_expression_numeric_operators
 from modules.optimizations.complex_operations import opt_value_of_const_array
 from modules.optimizations.dead_codes import opt_unused_variable, opt_remove_uninitialised_variable_usage
 from modules.optimizations.empty_nodes import opt_remove_empty_nodes
@@ -35,6 +35,7 @@ def optimize_pass(ast, stats):
         opt_binary_expression_format,
         opt_binary_expression_replace,
         opt_binary_expression_join,
+        opt_binary_expression_numeric_operators,
         # Invoke member
         opt_invoke_split_string,
         opt_invoke_replace_string,

--- a/modules/optimize.py
+++ b/modules/optimize.py
@@ -12,12 +12,11 @@ from modules.optimizations.empty_nodes import opt_remove_empty_nodes
 from modules.optimizations.invoke_member import opt_invoke_split_string, opt_invoke_replace_string, \
     opt_invoke_reverse_array, opt_invoke_expression
 from modules.optimizations.replace_long_names import opt_long_variable_names
-from modules.optimizations.simplifications import opt_simplify_paren_single_expression, \
+from modules.optimizations.simplifications import opt_convert_bogus_loops, opt_simplify_paren_single_expression, \
     opt_bareword_case, opt_constant_string_type, opt_prefixed_variable_case, opt_replace_constant_variable_by_value, \
     opt_simplify_single_array, opt_simplify_pipeline_single_command, opt_type_constraint_from_convert, \
-    opt_command_element_as_bareword, opt_type_constraint_case, opt_special_variable_case
-from modules.optimizations.type_convertions import opt_convert_type_to_type, opt_convert_type_to_char, \
-    opt_convert_type_to_array, opt_convert_type_to_string
+    opt_command_element_as_bareword, opt_type_constraint_case, opt_special_variable_case, \
+    opt_lift_switch_with_just_default
 from modules.optimizations.unary_expressions import opt_unary_expression_join
 
 
@@ -62,6 +61,8 @@ def optimize_pass(ast, stats):
         opt_command_element_as_bareword,
         opt_type_constraint_case,
         opt_alias,
+        opt_convert_bogus_loops,
+        opt_lift_switch_with_just_default,
         # Last
         opt_replace_constant_variable_by_value,
     ]

--- a/modules/scope.py
+++ b/modules/scope.py
@@ -1,0 +1,33 @@
+
+class Scope:
+
+    def __init__(self):
+        self._stack = []
+        self.enter()  # default "global" scope
+
+    def enter(self):
+        self._stack.append({})
+
+    def leave(self):
+        self._stack.pop()
+
+    def get_var(self, name):
+        for scope in reversed(self._stack):
+            if name in scope:
+                return scope[name]
+
+        return None
+
+    def set_var(self, name, value):
+        # FIXME Inside functions, writes to global variables (without prefix) must not be visible to the global scope
+        for scope in reversed(self._stack):
+            if name in scope:
+                scope[name] = value
+                break
+        else:
+            self._stack[-1][name] = value
+
+    def del_var(self, name):
+        for scope in self._stack:
+            if name in scope:
+                del scope[name]

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -25,6 +25,18 @@ def get_used_vars(ast):
     return used_vars
 
 
+def get_assigned_vars(ast):
+    vars = set()
+    for node in ast.iter():
+        if node.tag == "AssignmentStatementAst" or (
+                node.tag == "UnaryExpressionAst" and
+                node.attrib["TokenKind"] in ["PostfixPlusPlus", "PostfixMinusMinus"]):
+            if node[0].tag == "VariableExpressionAst":
+                vars.add(node[0].attrib["VariablePath"].lower())
+
+    return vars
+
+
 def create_constant_number(value):
     const_expr = Element("ConstantExpressionAst")
     const_expr.text = str(value)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -25,12 +25,19 @@ def get_used_vars(ast):
     return used_vars
 
 
+def create_constant_number(value):
+    const_expr = Element("ConstantExpressionAst")
+    const_expr.text = str(value)
+    const_expr.attrib["StaticType"] = "int" if isinstance(value, int) else "double"
+    return const_expr
+
+
 def create_constant_string(value, string_type="SingleQuoted"):
-    empty_string_element = Element("StringConstantExpressionAst")
-    empty_string_element.text = value
-    empty_string_element.attrib["StringConstantType"] = string_type
-    empty_string_element.attrib["StaticType"] = "string"
-    return empty_string_element
+    string_const_expr = Element("StringConstantExpressionAst")
+    string_const_expr.text = value
+    string_const_expr.attrib["StringConstantType"] = string_type
+    string_const_expr.attrib["StaticType"] = "string"
+    return string_const_expr
 
 
 def create_array_literal_values(values, string_type="SingleQuoted"):
@@ -80,8 +87,10 @@ def parent_map(ast):
     return dict((c, p) for p in ast.iter() for c in p)
 
 
-def replace_node(ast, old, new, until=None):
-    parents = parent_map(ast)
+def replace_node(ast, old, new, until=None, parents=None):
+    if parents is None:
+        parents = parent_map(ast)
+
     for i, element in enumerate(parents[old]):
         if element == old:
             if until is not None:
@@ -89,7 +98,11 @@ def replace_node(ast, old, new, until=None):
                     element = parents[element]
             if element in parents:
                 parents[element].remove(element)
-                parents[element].insert(i, new)
+                if not isinstance(new, (list, tuple)):
+                    parents[element].insert(i, new)
+                else:
+                    for j, new_elem in enumerate(new):
+                        parents[element].insert(i + j, new_elem)
                 break
 
 
@@ -102,6 +115,14 @@ def delete_node(ast, old, until=None):
                     element = parents[element]
             parents[element].remove(element)
             break
+
+
+def to_numeric(s):
+    try:
+        result = int(s)
+    except ValueError:
+        result = float(s)
+    return result
 
 
 def check_python_version():


### PR DESCRIPTION
My biggest and probably most controversial Pull Request here yet. Sorry for the size, I tried to split it into commits as best as possible.

I wanted to deobfuscate a script that heavily utilizes (constant) arithmetic, control-flow shenanigans and dead code. deobshell so far was mostly geared towards string manipulation, so I had to add quite a few things. The script of interest was around 450 KB and had over 150k AST nodes, which would take time in the range of hours to deobfuscate (I never ran it to completion with the original code). So I also optimized the way passes are applied and changed individual hot passes to batch changes rather than returning after every single change.

Other than those generic changes, there's the following new passes/improvements:
* Better constant propagation that also works if variables are used multiple times. For that, I made it block-scope-aware and added some constraints for loops to try and ensure correctness
* Fix bad results that were introduced when eliminating uninitialised variables from subtractions/multiplications (must be substituted with 0 rather than taking out the binary expression). The algorithm still has a bug where it isn't loop-aware (e.g., when summing up an unassigned var in a loop), which is marked with a `FIXME`, but this is not a new regression
* Add dead code elimination for if-clauses, switch-statements and loops if they have a condition that can be statically evaluated (e.g., always evaluates to false)
* Lift code from if-statements and switch-statements into parent block if expression can be statically evaluated; lift code from loops if the loop has an unconditional `break` at the end (and no other interfering `break`/`continue`)
* Strip `[int]` convert when expression is already `int` (most often happens after constant propagation)

I also ran this against the existing corpus of scripts and didn't see any output that took a turn for the worse.