### PR TITLE
Remove -it from Docker command to fix non-interactive execution

### DIFF
--- a/modules/ast.py
+++ b/modules/ast.py
@@ -36,7 +36,7 @@ def create_ast_file(ps1_file, use_docker):
 
         cmd = docker_cmd + ["run", "-v", os.path.abspath(os.path.join("tools", "Get-AST.ps1")) + ":/Get-AST.ps1",
             "-v", os.path.abspath(ps1_file / "..") + ":/scriptdir",
-            "--net", "none", "--rm", "-it", "mcr.microsoft.com/powershell:lts-7.2-ubuntu-22.04",
+            "--net", "none", "--rm", "mcr.microsoft.com/powershell:lts-7.2-ubuntu-22.04",
             "pwsh", "-File", "/Get-AST.ps1", "-ps1", "/scriptdir/" + ps1_file.name]
     else:
         cmd = ["PowerShell", "-ExecutionPolicy", "Unrestricted", "-File",


### PR DESCRIPTION
Fixes #20

The `-it` flags on the `docker run` command in `create_ast_file()` cause immediate failure when stdin is not a terminal (scripts, CI, piped execution). Since `Get-AST.ps1` requires no interactive input, these flags are unnecessary.

**Change:** Remove `-it` from the Docker command in `modules/ast.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)